### PR TITLE
Changes date format on the example

### DIFF
--- a/compositionality-template.tex
+++ b/compositionality-template.tex
@@ -1,4 +1,4 @@
-\documentclass[a4paper,superscriptaddress,11pt,accepted=22-07-2018,issuemonth=July, issueyear=2018, shorttitle=template]{compositionalityarticle}
+\documentclass[a4paper,superscriptaddress,11pt,accepted=2018-07-22,issuemonth=July, issueyear=2018, shorttitle=template]{compositionalityarticle}
 \pdfoutput=1
 \usepackage[utf8]{inputenc}
 \usepackage[english]{babel}


### PR DESCRIPTION
Currently, trying to compile the example using `pdflatex compositionality-template.tex` produces an error:

```
 ! Class compositionalityarticle Error: The date in the accepted option must be
 given in the format YYYY-MM-DD.
 See the compositionalityarticle class documentation for explanation.
```