### PR TITLE
Add https://doi.org to DOI

### DIFF
--- a/compositionalityarticle.cls
+++ b/compositionalityarticle.cls
@@ -1339,7 +1339,7 @@ class for Compositionality - the open journal for the mathematics of composition
 		\setlength{\bibsep}{0pt plus 0.3ex}
 		\@ifpackageloaded{doi}{}{%
 			\providecommand{\doi}[1]{}
-			\renewcommand{\doi}[1]{\href{https://doi.org/\detokenize{#1}}{DOI: \detokenize{#1}}}%
+			\renewcommand{\doi}[1]{\href{https://doi.org/\detokenize{#1}}{https://doi.org/\detokenize{#1}}}%
 		}%
 	}{%
 		\@ifpackageloaded{biblatex}{


### PR DESCRIPTION
If I understand correctly, it is desired to print out the DOIs starting with `https://doi.org` in the bibliography.
However, using the doi field as suggested in your example
```
@article{examplecitation,
author = {Surname, Name},
title = {Title},
journal = {Compositionality},
volume = {123},
page = {123456},
year = {1916},
doi = {10.22331/idonotexist},
}
```
in combination with the compositionalityarticle class currently produces
`DOI: 10.22331/idonotexist`

Since I think it is recommended to use the doi, and not the doi link within the doi field,
I suggest changing the `\doi` command in the compositionalityarticle class.